### PR TITLE
Allow specifying server IP address separately from hostname

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::error::Error;
+use std::net::{IpAddr,Ipv4Addr};
 
 use ldap3::{LdapConn,LdapConnSettings};
 
@@ -17,6 +18,7 @@ fn main() {
 
 fn connect() -> Result<(), Box<dyn Error>> {
     let mut ldap_server_url: Option<&str> = None;
+    let mut ldap_server_ip: Option<&str> = None;
     let mut ldap_username: Option<&str> = None;
     let mut ldap_password: Option<&str> = None;
     let mut ldap_bind_type: Option<&str> = None;
@@ -45,6 +47,9 @@ fn connect() -> Result<(), Box<dyn Error>> {
                 },
                 "server-url" => {
                     ldap_server_url = Some(value);
+                },
+                "server-ip" => {
+                    ldap_server_ip = Some(value);
                 },
                 "bind-type" => {
                     ldap_bind_type = Some(value);
@@ -76,6 +81,13 @@ fn connect() -> Result<(), Box<dyn Error>> {
     println!("LdapCertificateValidation: {}", ldap_certificate_validation);
 
     let mut ldap_settings = LdapConnSettings::new().set_no_tls_verify(!ldap_certificate_validation);
+
+    if let Some(ldap_server_ip) = ldap_server_ip {
+        if let Ok(ip_address) = ldap_server_ip.parse::<Ipv4Addr>() {
+            let ip_address = IpAddr::V4(ip_address);
+            ldap_settings = ldap_settings.set_ip_address(&ip_address);
+        }
+    }
 
     if let Some(ldap_trusted_root_ca_file) = ldap_trusted_root_ca_file {
         println!("LdapTrustedRootCaFile: {}", ldap_trusted_root_ca_file);


### PR DESCRIPTION
In cases where DNS is not properly configured, or the hostname cannot be resolved, allow specifying the server IP address manually. This can be particularly helpful to get the certificate validation working correctly by using the proper hostname in the LDAP server URL but providing the real IP address.